### PR TITLE
Remove cosign version specification in Docker workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,8 +50,6 @@ jobs:
       - name: Install cosign
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 #v3.4.0
-        with:
-          cosign-release: 'v2.1.1'
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache


### PR DESCRIPTION
This commit removes the redundant specification of the cosign version in the Docker publishing GitHub workflow. The utilization of specific versions is no longer necessary due to updates in the workflow management rules.