### PR TITLE
Add read-only permissions to SonarQube workflow file

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main # or the name of your main branch
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Introduced `permissions: read-all` to SonarQube GitHub workflow file. This modification enforces default read-only permissions to enhance the security of the workflow.