### PR TITLE
Added Private Captcha support for form validation middleware

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,13 +15,13 @@ type Config struct {
 	Loglevel string `fig:"loglevel" default:"debug"`
 	Forms    struct {
 		Path string `fig:"path" validate:"required"`
-	}
+	} `fig:"forms"`
 	Server struct {
 		Addr         string        `fig:"bind_addr"`
 		Port         uint32        `fig:"port" default:"8765"`
 		Timeout      time.Duration `fig:"timeout" default:"15s"`
 		RequestLimit string        `fig:"request_limit" default:"10M"`
-	}
+	} `fig:"server"`
 }
 
 // NewConfig returns a new Config object and fails if the configuration was not found or

--- a/form/form.go
+++ b/form/form.go
@@ -52,6 +52,12 @@ type Form struct {
 			Enabled   bool   `fig:"enabled"`
 			SecretKey string `fig:"secret_key"`
 		}
+		PrivateCaptcha struct {
+			Host    string `fig:"host"`
+			Enabled bool   `fig:"enabled"`
+			SiteKey string `fig:"site_key"`
+			APIKey  string `fig:"api_key"`
+		} `fig:"private_captcha"`
 	}
 }
 

--- a/server/router_api.go
+++ b/server/router_api.go
@@ -19,5 +19,5 @@ func (s *Srv) RouterAPI() {
 	ag.Add("POST", "/send/:fid/:token", apiRoute.SendForm,
 		apiRoute.SendFormBindForm, apiRoute.SendFormReqFields, apiRoute.SendFormHoneypot,
 		apiRoute.SendFormHcaptcha, apiRoute.SendFormRecaptcha, apiRoute.SendFormTurnstile,
-		apiRoute.SendFormCheckToken)
+		apiRoute.SendFormPrivateCaptcha, apiRoute.SendFormCheckToken)
 }


### PR DESCRIPTION
- Introduced `PrivateCaptcha` struct in form configuration
- Implemented `SendFormPrivateCaptcha` middleware for validating Private Captcha challenge-responses
- Updated router to include `SendFormPrivateCaptcha` in form submission endpoint
- Refined constant error messages for consistency and added new error for Private Captcha validation
- Adjusted configuration structure annotations for better clarity