### PR TITLE
Added support for CSV attachment in form submissions

### DIFF
--- a/internal/forms/form.go
+++ b/internal/forms/form.go
@@ -27,6 +27,7 @@ type Form struct {
 		Content        string `fig:"content"`
 	}
 	Domains    []string `fig:"domains" validate:"required"`
+	AttachCSV  bool     `fig:"attach_csv"`
 	ID         string   `fig:"id" validate:"required"`
 	Recipients []string `fig:"recipients" validate:"required"`
 	ReplyTo    struct {

--- a/internal/server/csv.go
+++ b/internal/server/csv.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Winni Neessen <wn@neessen.dev>
+//
+// SPDX-License-Identifier: MIT
+
+package server
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+func (s *Server) csvFromFields(dst io.Writer, r *http.Request) error {
+	writer := csv.NewWriter(dst)
+	writer.UseCRLF = false
+	writer.Comma = ';'
+	values := r.MultipartForm.Value
+
+	headers := make([]string, 0, len(values))
+	for field := range values {
+		headers = append(headers, field)
+	}
+	if err := writer.Write(headers); err != nil {
+		return fmt.Errorf("failed to write CSV header: %w", err)
+	}
+
+	row := make([]string, len(headers))
+	for i, field := range headers {
+		row[i] = strings.Join(values[field], "\n")
+	}
+	if err := writer.Write(row); err != nil {
+		return fmt.Errorf("failed to write CSV row: %w", err)
+	}
+
+	writer.Flush()
+	return writer.Error()
+}

--- a/internal/server/sendmail.go
+++ b/internal/server/sendmail.go
@@ -5,6 +5,7 @@
 package server
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"strings"
@@ -101,6 +102,16 @@ func (s *Server) sendMessage(r *http.Request, form *forms.Form, client *mail.Cli
 		}
 		if err := message.ReplyTo(replyto); err != nil {
 			return "", fmt.Errorf("failed to set reply-to address: %w", err)
+		}
+	}
+
+	if form.AttachCSV {
+		buf := bytes.NewBuffer(nil)
+		if err := s.csvFromFields(buf, r); err != nil {
+			return "", fmt.Errorf("failed to read fields into CSV: %w", err)
+		}
+		if err := message.AttachReader("submission.csv", buf); err != nil {
+			return "", fmt.Errorf("failed to attach CSV file to message: %w", err)
 		}
 	}
 


### PR DESCRIPTION
- Introduced `AttachCSV` configuration option in `form.go` to enable CSV generation
- Implemented `csvFromFields` function to generate and write form field data to a CSV file
- Updated `sendmail.go` to attach the generated CSV file to outgoing emails when enabled
- Added unit tests for `csvFromFields` to validate CSV generation and error handling scenarios
- Enhanced test helper methods and introduced `failWriter` for testing edge cases with writers