### PR TITLE
Sorted CSV headers alphabetically before writing

### DIFF
--- a/internal/server/csv.go
+++ b/internal/server/csv.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 )
 
@@ -22,6 +23,8 @@ func (s *Server) csvFromFields(dst io.Writer, r *http.Request) error {
 	for field := range values {
 		headers = append(headers, field)
 	}
+	slices.Sort(headers)
+
 	if err := writer.Write(headers); err != nil {
 		return fmt.Errorf("failed to write CSV header: %w", err)
 	}


### PR DESCRIPTION
- Added `slices.Sort` to alphabetically sort headers in `csv.go`
- Ensured consistent ordering of CSV fields for better usability and readability