### PR TITLE
Use CHI client IP for captcha and routing

### DIFF
--- a/internal/server/handler_sendform.go
+++ b/internal/server/handler_sendform.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/render"
 
 	"github.com/wneessen/js-mailer/internal/cache"
@@ -151,7 +152,11 @@ func (s *Server) HandlerAPISendFormPost(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Check form submission against the configured captcha provider
-	if err = s.validateCaptcha(r.Context(), form, r.MultipartForm.Value, r.RemoteAddr); err != nil {
+	clientIP := r.RemoteAddr
+	if val := middleware.GetClientIP(r.Context()); val != "" {
+		clientIP = val
+	}
+	if err = s.validateCaptcha(r.Context(), form, r.MultipartForm.Value, clientIP); err != nil {
 		log.Error("captcha validation failed", logger.Err(err))
 		_ = render.Render(w, r, ErrNotFound(ErrCaptchaValidationFailed))
 		return

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -43,7 +43,7 @@ func (s *Server) routes(_ context.Context) {
 	// Register middleware
 	s.mux.Use(s.serverHeader)
 	s.mux.Use(middleware.RequestID)
-	s.mux.Use(middleware.RealIP)
+	s.mux.Use(middleware.ClientIPFromHeader("X-Real-IP"))
 	s.mux.Use(middleware.StripSlashes)
 	s.mux.Use(middleware.Compress(5))
 	s.mux.Use(logHandler)


### PR DESCRIPTION
Replaces `middleware.RealIP` with the secure alternative.

Further details in: GHSA-3fxj-6jh8-hvhx, GHSA-rjr7-jggh-pgcp, GHSA-9g5q-2w5x-hmxf